### PR TITLE
Handle rejection to prevent endless tests

### DIFF
--- a/src/package/utils/Expect.ts
+++ b/src/package/utils/Expect.ts
@@ -1,5 +1,6 @@
 import {testController} from '../testController';
 
+import {E2EDError} from './E2EDError';
 import {log} from './log';
 import {valueToString} from './valueToString';
 
@@ -46,25 +47,37 @@ export class Expect {
 
 for (const [key, getAssertionMessage] of Object.entries(assertions)) {
   Expect.prototype[key] = function method(...args: unknown[]) {
-    const message = getAssertionMessage(...args);
+    const payload = {description: this.description};
+    const expectedDescription = getAssertionMessage(...args);
 
+    // Wrap the actual value in a promise, then convert it to a string.
+    const actualPromise = Promise.resolve(this.actual).then(valueToString);
+
+    // Wrap the assertion in a promise, then convert the result into a boolean.
     const assertPromise = new Promise((resolve) => {
       const assert = testController.expect(this.actual) as Assert<Promise<void>>;
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      assert[key as AssertionKeys](...args).then(resolve);
+      assert[key as AssertionKeys](...args)
+        .then(() => resolve(true))
+        .catch(() => resolve(false));
     });
 
-    return assertPromise
-      .then(() => this.actual)
-      .then((actual) =>
-        log(
-          `Assert that value ${valueToString(actual)} ${message}`,
-          {
-            description: this.description,
-          },
-          'internalAssert',
-        ),
-      );
+    return Promise.all([actualPromise, assertPromise])
+      .then(([actual, isExpected]) => {
+        if (isExpected) {
+          return log(
+            `Assert that value ${actual} ${expectedDescription}`,
+            payload,
+            'internalAssert',
+          );
+        }
+
+        throw `Expected that value ${actual} ${expectedDescription}`;
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+
+        throw new E2EDError(message, payload);
+      });
   };
 }


### PR DESCRIPTION
And create an error message in the general format.